### PR TITLE
feat: Expand analyzer rules to cover template strings

### DIFF
--- a/src/CompositeKey.Analyzers.Common.UnitTests/Validation/TemplateValidationTests.cs
+++ b/src/CompositeKey.Analyzers.Common.UnitTests/Validation/TemplateValidationTests.cs
@@ -1,0 +1,728 @@
+using CompositeKey.Analyzers.Common.Diagnostics;
+using CompositeKey.Analyzers.Common.Tokenization;
+using CompositeKey.Analyzers.Common.Validation;
+
+namespace CompositeKey.Analyzers.Common.UnitTests.Validation;
+
+public static class TemplateValidationTests
+{
+    public class ValidateTemplateStringTests
+    {
+        [Fact]
+        public void ValidTemplate_ShouldReturnSuccess()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}";
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateString(templateString);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("   ")]
+        [InlineData("\t")]
+        [InlineData("\n")]
+        public void EmptyOrWhitespaceTemplate_ShouldReturnFailure(string? templateString)
+        {
+            // Act
+            var result = TemplateValidation.ValidateTemplateString(templateString);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs.Length.ShouldBe(1);
+            result.MessageArgs[0].ShouldBe(templateString ?? string.Empty);
+        }
+    }
+
+    public class ValidatePrimaryKeySeparatorTests
+    {
+        [Fact]
+        public void TemplateWithPrimaryKeySeparator_WhenSeparatorPresent_ShouldReturnSuccess()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}#POST#{PostId}";
+            const char separator = '#';
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.PrimaryDelimiter('#'),
+                TemplateToken.Property("UserId"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Constant("POST"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("PostId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePrimaryKeySeparator(templateString, separator, tokens);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TemplateWithoutPrimaryKeySeparator_WhenSeparatorNotRequired_ShouldReturnSuccess()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}";
+            char? separator = null;
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePrimaryKeySeparator(templateString, separator, tokens);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TemplateWithoutPrimaryKeySeparator_WhenSeparatorRequired_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}";
+            const char separator = '#';
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePrimaryKeySeparator(templateString, separator, tokens);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PrimaryKeySeparatorMissingFromTemplateString);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs.Length.ShouldBe(2);
+            result.MessageArgs[0].ShouldBe(templateString);
+            result.MessageArgs[1].ShouldBe(separator);
+        }
+    }
+
+    public class ValidatePropertyReferencesTests
+    {
+        [Fact]
+        public void AllPropertiesExistWithGettersAndSetters_ShouldReturnSuccess()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("Name")
+            };
+
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("Name", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("Email", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePropertyReferences(tokens, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void PropertyDoesNotExist_ShouldReturnFailure()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Property("NonExistentProperty")
+            };
+
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("Name", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePropertyReferences(tokens, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs.Length.ShouldBe(1);
+            result.MessageArgs[0].ShouldBe("NonExistentProperty");
+        }
+
+        [Fact]
+        public void PropertyWithoutGetter_ShouldReturnFailure()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Property("WriteOnlyProperty")
+            };
+
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("WriteOnlyProperty", HasGetter: false, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePropertyReferences(tokens, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+        }
+
+        [Fact]
+        public void PropertyWithoutSetter_ShouldReturnFailure()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Property("ReadOnlyProperty")
+            };
+
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("ReadOnlyProperty", HasGetter: true, HasSetter: false)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePropertyReferences(tokens, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+        }
+
+        [Fact]
+        public void NoPropertyTokens_ShouldReturnSuccess()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Constant("123")
+            };
+
+            var availableProperties = Array.Empty<TemplateValidation.PropertyInfo>();
+
+            // Act
+            var result = TemplateValidation.ValidatePropertyReferences(tokens, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+    }
+
+    public class TokenizeTemplateStringTests
+    {
+        [Fact]
+        public void SimpleTemplate_ShouldTokenizeCorrectly()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeTrue();
+            result.Tokens.Count.ShouldBe(3);
+            result.Tokens[0].ShouldBeOfType<ConstantTemplateToken>();
+            ((ConstantTemplateToken)result.Tokens[0]).Value.ShouldBe("USER");
+            result.Tokens[1].ShouldBeOfType<DelimiterTemplateToken>();
+            result.Tokens[2].ShouldBeOfType<PropertyTemplateToken>();
+            ((PropertyTemplateToken)result.Tokens[2]).Name.ShouldBe("UserId");
+        }
+
+        [Fact]
+        public void TemplateWithFormatSpecifier_ShouldTokenizeCorrectly()
+        {
+            // Arrange
+            const string templateString = "{Id:D}";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeTrue();
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].ShouldBeOfType<PropertyTemplateToken>();
+            var propertyToken = (PropertyTemplateToken)result.Tokens[0];
+            propertyToken.Name.ShouldBe("Id");
+            propertyToken.Format.ShouldBe("D");
+        }
+
+        [Fact]
+        public void TemplateWithSinglePrimaryKeySeparator_ShouldIdentifyPrimaryDelimiter()
+        {
+            // Arrange
+            const string templateString = "USER_{UserId}#{PostId}";
+            const char separator = '#';
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeTrue();
+            result.Tokens.OfType<PrimaryDelimiterTemplateToken>().Count().ShouldBe(1);
+            result.Tokens.OfType<DelimiterTemplateToken>().Count().ShouldBe(1); // Only the '_'
+            var primaryDelimiterIndex = result.Tokens.FindIndex(t => t is PrimaryDelimiterTemplateToken);
+            primaryDelimiterIndex.ShouldBe(3); // After "USER", "_", and "{UserId}"
+        }
+
+        [Fact]
+        public void TemplateWithMultiplePrimaryKeySeparators_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "USER#{UserId}#POST#{PostId}";
+            const char separator = '#';
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeFalse(); // Multiple '#' when '#' is the primary separator is invalid
+        }
+
+        [Fact]
+        public void EmptyTemplate_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void MalformedProperty_UnclosedBrace_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "{UserId";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NestedBraces_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "{User{Id}}";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void MultipleDelimiters_ShouldTokenizeCorrectly()
+        {
+            // Arrange
+            const string templateString = "A-B_C#D";
+            char? separator = null;
+
+            // Act
+            var result = TemplateValidation.TokenizeTemplateString(templateString, separator);
+
+            // Assert
+            result.Success.ShouldBeTrue();
+            result.Tokens.Count.ShouldBe(7);
+            result.Tokens[0].ShouldBeOfType<ConstantTemplateToken>();
+            result.Tokens[1].ShouldBeOfType<DelimiterTemplateToken>();
+            result.Tokens[2].ShouldBeOfType<ConstantTemplateToken>();
+            result.Tokens[3].ShouldBeOfType<DelimiterTemplateToken>();
+            result.Tokens[4].ShouldBeOfType<ConstantTemplateToken>();
+            result.Tokens[5].ShouldBeOfType<DelimiterTemplateToken>();
+            result.Tokens[6].ShouldBeOfType<ConstantTemplateToken>();
+        }
+    }
+
+    public class HasValidTemplateStructureTests
+    {
+        [Fact]
+        public void TemplateWithPropertyToken_ShouldReturnTrue()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Property("UserId")
+            };
+
+            // Act
+            var result = TemplateValidation.HasValidTemplateStructure(tokens);
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TemplateWithConstantToken_ShouldReturnTrue()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER")
+            };
+
+            // Act
+            var result = TemplateValidation.HasValidTemplateStructure(tokens);
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TemplateWithMixedValueTokens_ShouldReturnTrue()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId")
+            };
+
+            // Act
+            var result = TemplateValidation.HasValidTemplateStructure(tokens);
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TemplateWithOnlyDelimiters_ShouldReturnFalse()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Delimiter('-'),
+                TemplateToken.PrimaryDelimiter('#')
+            };
+
+            // Act
+            var result = TemplateValidation.HasValidTemplateStructure(tokens);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void EmptyTokenList_ShouldReturnFalse()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>();
+
+            // Act
+            var result = TemplateValidation.HasValidTemplateStructure(tokens);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+    }
+
+    public class ValidatePartitionAndSortKeyStructureTests
+    {
+        [Fact]
+        public void ValidCompositeKey_ShouldReturnTrue()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId"),
+                TemplateToken.PrimaryDelimiter('#'),
+                TemplateToken.Constant("POST"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("PostId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePartitionAndSortKeyStructure(tokens, out int primaryDelimiterIndex);
+
+            // Assert
+            result.ShouldBeTrue();
+            primaryDelimiterIndex.ShouldBe(3);
+        }
+
+        [Fact]
+        public void NoPrimaryDelimiter_ShouldReturnTrue()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePartitionAndSortKeyStructure(tokens, out int primaryDelimiterIndex);
+
+            // Assert
+            result.ShouldBeTrue();
+            primaryDelimiterIndex.ShouldBe(-1);
+        }
+
+        [Fact]
+        public void PrimaryDelimiterWithoutPartitionKeyValues_ShouldReturnFalse()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.PrimaryDelimiter('#'),
+                TemplateToken.Constant("POST"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("PostId")
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePartitionAndSortKeyStructure(tokens, out _);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void PrimaryDelimiterWithoutSortKeyValues_ShouldReturnFalse()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Constant("USER"),
+                TemplateToken.Delimiter('#'),
+                TemplateToken.Property("UserId"),
+                TemplateToken.PrimaryDelimiter('#')
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePartitionAndSortKeyStructure(tokens, out _);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void PrimaryDelimiterWithOnlyDelimitersOnBothSides_ShouldReturnFalse()
+        {
+            // Arrange
+            var tokens = new List<TemplateToken>
+            {
+                TemplateToken.Delimiter('#'),
+                TemplateToken.PrimaryDelimiter('#'),
+                TemplateToken.Delimiter('#')
+            };
+
+            // Act
+            var result = TemplateValidation.ValidatePartitionAndSortKeyStructure(tokens, out _);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+    }
+
+    public class ValidateTemplateFormatTests
+    {
+        [Fact]
+        public void ValidCompleteTemplate_ShouldReturnSuccess()
+        {
+            // Arrange
+            const string templateString = "USER_{UserId}#{PostId}";
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("PostId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void EmptyTemplate_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "";
+            char? separator = null;
+            var availableProperties = Array.Empty<TemplateValidation.PropertyInfo>();
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString);
+        }
+
+        [Fact]
+        public void InvalidCompositeKeyStructure_NoPartitionKey_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "#{UserId}"; // No partition key part before separator
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString); // Invalid structure - no partition key
+        }
+
+        [Fact]
+        public void InvalidCompositeKeyStructure_NoSortKey_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "{UserId}#"; // No sort key part after separator
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString); // Invalid structure - no sort key
+        }
+
+        [Fact]
+        public void TemplateWithoutSeparatorChar_WhenSeparatorRequired_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "USER_{UserId}"; // No '#' character at all
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PrimaryKeySeparatorMissingFromTemplateString);
+        }
+
+        [Fact]
+        public void InvalidPropertyReference_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "{NonExistentProperty}";
+            char? separator = null;
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+        }
+
+        [Fact]
+        public void OnlyDelimiters_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "###";
+            char? separator = null;
+            var availableProperties = Array.Empty<TemplateValidation.PropertyInfo>();
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString);
+        }
+
+        [Fact]
+        public void InvalidPartitionKeyStructure_ShouldReturnFailure()
+        {
+            // Arrange
+            const string templateString = "#{PostId}";
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("PostId", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.EmptyOrInvalidTemplateString);
+        }
+
+        [Fact]
+        public void ComplexValidTemplate_WithFormatSpecifiers_ShouldReturnSuccess()
+        {
+            // Arrange
+            const string templateString = "USER_{UserId:D}#POST_{PostId:N}-{Timestamp:yyyy-MM-dd}";
+            const char separator = '#';
+            var availableProperties = new[]
+            {
+                new TemplateValidation.PropertyInfo("UserId", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("PostId", HasGetter: true, HasSetter: true),
+                new TemplateValidation.PropertyInfo("Timestamp", HasGetter: true, HasSetter: true)
+            };
+
+            // Act
+            var result = TemplateValidation.ValidateTemplateFormat(templateString, separator, availableProperties.ToList());
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+    }
+}

--- a/src/CompositeKey.Analyzers.Common/Tokenization/TemplateStringTokenizer.cs
+++ b/src/CompositeKey.Analyzers.Common/Tokenization/TemplateStringTokenizer.cs
@@ -1,4 +1,4 @@
-﻿namespace CompositeKey.SourceGeneration.Core.Tokenization;
+namespace CompositeKey.Analyzers.Common.Tokenization;
 
 public class TemplateStringTokenizer(char? primaryKeySeparator)
 {
@@ -34,11 +34,18 @@ public class TemplateStringTokenizer(char? primaryKeySeparator)
             }
             else
             {
-                var templateToken = _primaryKeySeparator == current
-                    ? TemplateToken.PrimaryDelimiter(current)
-                    : TemplateToken.Delimiter(current);
+                if (_primaryKeySeparator == current)
+                {
+                    if (templateTokens.Any(tt => tt.Type == TemplateToken.TemplateTokenType.PrimaryDelimiter))
+                        return TokenizeResult.CreateFailure();
 
-                templateTokens.Add(templateToken);
+                    templateTokens.Add(TemplateToken.PrimaryDelimiter(current));
+                }
+                else
+                {
+                    templateTokens.Add(TemplateToken.Delimiter(current));
+                }
+
                 currentPosition++;
             }
         }

--- a/src/CompositeKey.Analyzers.Common/Tokenization/TemplateToken.cs
+++ b/src/CompositeKey.Analyzers.Common/Tokenization/TemplateToken.cs
@@ -1,4 +1,4 @@
-﻿namespace CompositeKey.SourceGeneration.Core.Tokenization;
+namespace CompositeKey.Analyzers.Common.Tokenization;
 
 public abstract record TemplateToken(TemplateToken.TemplateTokenType Type)
 {

--- a/src/CompositeKey.Analyzers.Common/Validation/TemplateValidation.cs
+++ b/src/CompositeKey.Analyzers.Common/Validation/TemplateValidation.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics.CodeAnalysis;
+using CompositeKey.Analyzers.Common.Diagnostics;
+using CompositeKey.Analyzers.Common.Tokenization;
+using Microsoft.CodeAnalysis;
+
+namespace CompositeKey.Analyzers.Common.Validation;
+
+public static class TemplateValidation
+{
+    public record TemplateValidationResult
+    {
+        [MemberNotNullWhen(false, nameof(Descriptor), nameof(MessageArgs))]
+        public required bool IsSuccess { get; init; }
+
+        public DiagnosticDescriptor? Descriptor { get; init; }
+        public object?[]? MessageArgs { get; init; }
+
+        public static TemplateValidationResult Success() => new()
+        {
+            IsSuccess = true
+        };
+
+        public static TemplateValidationResult Failure(DiagnosticDescriptor descriptor, params object?[] messageArgs) => new()
+        {
+            IsSuccess = false,
+            Descriptor = descriptor,
+            MessageArgs = messageArgs
+        };
+    }
+
+    public record PropertyInfo(string Name, bool HasGetter, bool HasSetter);
+
+    public static TemplateValidationResult ValidateTemplateString(string? templateString)
+    {
+        if (string.IsNullOrWhiteSpace(templateString))
+        {
+            return TemplateValidationResult.Failure(
+                DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+                templateString ?? string.Empty);
+        }
+
+        return TemplateValidationResult.Success();
+    }
+
+    public static TemplateValidationResult ValidatePrimaryKeySeparator(
+        string templateString,
+        char? primaryKeySeparator,
+        List<TemplateToken> tokens)
+    {
+        if (primaryKeySeparator.HasValue && tokens.All(t => t.Type != TemplateToken.TemplateTokenType.PrimaryDelimiter))
+        {
+            return TemplateValidationResult.Failure(
+                DiagnosticDescriptors.PrimaryKeySeparatorMissingFromTemplateString,
+                templateString, primaryKeySeparator.Value);
+        }
+
+        return TemplateValidationResult.Success();
+    }
+
+    public static TemplateValidationResult ValidatePropertyReferences(
+        List<TemplateToken> tokens,
+        List<PropertyInfo> availableProperties)
+    {
+        var propertyTokens = tokens.OfType<PropertyTemplateToken>();
+        foreach (var token in propertyTokens)
+        {
+            var property = availableProperties.FirstOrDefault(p => p.Name == token.Name);
+            if (property == null || !property.HasGetter || !property.HasSetter)
+            {
+                return TemplateValidationResult.Failure(
+                    DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter,
+                    token.Name);
+            }
+        }
+
+        return TemplateValidationResult.Success();
+    }
+
+    public static bool HasValidTemplateStructure(List<TemplateToken> tokens)
+    {
+        return tokens.Any() && tokens.Any(t => t.Type is TemplateToken.TemplateTokenType.Property or TemplateToken.TemplateTokenType.Constant);
+    }
+
+    public static bool ValidatePartitionAndSortKeyStructure(
+        List<TemplateToken> tokens,
+        out int primaryDelimiterIndex)
+    {
+        primaryDelimiterIndex = -1;
+
+        var primaryDelimiterToken = tokens.FirstOrDefault(t => t.Type == TemplateToken.TemplateTokenType.PrimaryDelimiter);
+        if (primaryDelimiterToken == null)
+            return true; // No composite key, just simple key
+
+        primaryDelimiterIndex = tokens.IndexOf(primaryDelimiterToken);
+
+        // Check if there are value parts before the delimiter (partition key)
+        var hasPartitionKeyValues = tokens
+            .Take(primaryDelimiterIndex)
+            .Any(t => t.Type == TemplateToken.TemplateTokenType.Property || t.Type == TemplateToken.TemplateTokenType.Constant);
+
+        // Check if there are value parts after the delimiter (sort key)
+        var hasSortKeyValues = tokens
+            .Skip(primaryDelimiterIndex + 1)
+            .Any(t => t.Type == TemplateToken.TemplateTokenType.Property || t.Type == TemplateToken.TemplateTokenType.Constant);
+
+        return hasPartitionKeyValues && hasSortKeyValues;
+    }
+
+    public static TokenizeResult TokenizeTemplateString(string templateString, char? primaryKeySeparator)
+    {
+        var tokenizer = new TemplateStringTokenizer(primaryKeySeparator);
+        return tokenizer.Tokenize(templateString.AsSpan());
+    }
+
+    public static TemplateValidationResult ValidateTemplateFormat(
+        string templateString,
+        char? primaryKeySeparator,
+        List<PropertyInfo> availableProperties)
+    {
+        // Basic validation
+        var basicValidation = ValidateTemplateString(templateString);
+        if (!basicValidation.IsSuccess)
+            return basicValidation;
+
+        // Tokenize the template
+        var tokenizationResult = TokenizeTemplateString(templateString, primaryKeySeparator);
+        if (!tokenizationResult.Success)
+        {
+            return TemplateValidationResult.Failure(
+                DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+                templateString);
+        }
+
+        // Validate primary key separator if specified
+        var separatorValidation = ValidatePrimaryKeySeparator(templateString, primaryKeySeparator, tokenizationResult.Tokens);
+        if (!separatorValidation.IsSuccess)
+            return separatorValidation;
+
+        // Validate template structure
+        if (!HasValidTemplateStructure(tokenizationResult.Tokens))
+        {
+            return TemplateValidationResult.Failure(
+                DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+                templateString);
+        }
+
+        // If it's a composite key, validate partition and sort key structure
+        if (primaryKeySeparator.HasValue)
+        {
+            if (!ValidatePartitionAndSortKeyStructure(tokenizationResult.Tokens, out _))
+            {
+                return TemplateValidationResult.Failure(
+                    DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+                    templateString);
+            }
+        }
+
+        // Validate property references
+        var propertyValidation = ValidatePropertyReferences(tokenizationResult.Tokens, availableProperties);
+        if (!propertyValidation.IsSuccess)
+            return propertyValidation;
+
+        return TemplateValidationResult.Success();
+    }
+}

--- a/src/CompositeKey.Analyzers.UnitTests/Analyzers/TemplateStringAnalyzerTests.cs
+++ b/src/CompositeKey.Analyzers.UnitTests/Analyzers/TemplateStringAnalyzerTests.cs
@@ -1,0 +1,808 @@
+using CompositeKey.Analyzers.Analyzers;
+using CompositeKey.Analyzers.UnitTests.Infrastructure;
+using Microsoft.CodeAnalysis;
+
+namespace CompositeKey.Analyzers.UnitTests.Analyzers;
+
+/// <summary>
+/// Comprehensive tests for TemplateStringAnalyzer validating template string format,
+/// primary key separator requirements, and precise diagnostic location targeting.
+/// </summary>
+public class TemplateStringAnalyzerTests
+{
+    /// <summary>
+    /// Tests for template format validation (COMPOSITE0005).
+    /// </summary>
+    public class TemplateFormatValidation
+    {
+        [Fact]
+        public async Task ValidTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{Id}#{Name}")]
+                    public partial record TestRecord(string Id, string Name);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ValidTemplateWithConstants_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("USER_{UserId}_TENANT_{TenantId}")]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ValidTemplateWithFormatting_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+                    using System;
+
+                    [CompositeKey("Order_{OrderId:D8}_{Date:yyyy-MM-dd}")]
+                    public partial record OrderKey(int OrderId, DateTime Date);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task EmptyTemplate_ReportsAtTemplateString()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:""|})]
+                    public partial record TestRecord(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task WhitespaceOnlyTemplate_ReportsAtTemplateString()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"   "|})]
+                    public partial record TestRecord(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithOnlyProperty_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{Id}")]
+                    public partial record TestRecord(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithOnlyConstant_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("CONSTANT_KEY")]
+                    public partial record TestRecord();
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ComplexTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+                    using System;
+
+                    [CompositeKey("PREFIX_{Part1}_{Part2:D3}_{Part3}_SUFFIX")]
+                    public partial record ComplexKey(string Part1, int Part2, Guid Part3);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithOnlyDelimiter_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"#"|})]
+                    public partial record TestKey(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithUnclosedPropertyBrace_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"{UnfinishedProperty"|})]
+                    public partial record TestKey(string UnfinishedProperty);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithNestedBraces_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"{Property{Nested}}"|})]
+                    public partial record TestKey(string Property);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Tests for primary key separator validation (COMPOSITE0006).
+    /// </summary>
+    public class PrimaryKeySeparatorValidation
+    {
+        [Fact]
+        public async Task TemplateWithSeparator_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{UserId}|{TenantId}", PrimaryKeySeparator = '|')]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MissingSeparator_ReportsAtPrimaryKeySeparatorProperty()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{UserId}_{TenantId}", {|COMPOSITE0006:PrimaryKeySeparator = '#'|})]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task OnlySeparator_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"|"|}, PrimaryKeySeparator = '|')]
+                    public partial record UserKey(string UserId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SeparatorAtBeginning_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"|{UserId}_{TenantId}"|}, PrimaryKeySeparator = '|')]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SeparatorAtEnd_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"{UserId}_{TenantId}|"|}, PrimaryKeySeparator = '|')]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MultipleSeparatorOccurrences_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{Part1}|{Part2}_{Part3}", PrimaryKeySeparator = '|')]
+                    public partial record ComplexKey(string Part1, string Part2, string Part3);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SeparatorWithoutProperty_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{UserId}#{TenantId}")]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ComplexTemplateWithMissingSeparator_ReportsError()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+                    using System;
+
+                    [CompositeKey("PREFIX_{Part1}_{Part2:D3}_{Part3}_SUFFIX", {|COMPOSITE0006:PrimaryKeySeparator = '|'|})]
+                    public partial record ComplexKey(string Part1, int Part2, Guid Part3);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SeparatorBetweenDelimitersOnly_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"_|_"|}, PrimaryKeySeparator = '|')]
+                    public partial record TestKey(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MultipleSeparatorsWithInvalidStructure_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"{Part1}|{Part2}|"|}, PrimaryKeySeparator = '|')]
+                    public partial record TestKey(string Part1, string Part2);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SeparatorAsFirstAndLastChar_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"|{UserId}|"|}, PrimaryKeySeparator = '|')]
+                    public partial record TestKey(string UserId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ConsecutiveSeparators_ReportsInvalidTemplate()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey({|COMPOSITE0005:"{Part1}||{Part2}"|}, PrimaryKeySeparator = '|')]
+                    public partial record TestKey(string Part1, string Part2);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+    }
+
+    /// <summary>
+    /// Tests for precise location targeting within template strings.
+    /// </summary>
+    public class LocationPrecision
+    {
+        [Fact]
+        public async Task EmptyTemplate_TargetsTemplateStringArgument()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey(
+                        {|COMPOSITE0005:""|}
+                    )]
+                    public partial record TestRecord(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MissingSeparator_TargetsPrimaryKeySeparatorProperty()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey(
+                        "User_{UserId}_{TenantId}",
+                        {|COMPOSITE0006:PrimaryKeySeparator = '#'|}
+                    )]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AttributeWithNamedArguments_TargetsCorrectly()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey(
+                        template: {|COMPOSITE0005:""|},
+                        InvariantCulture = true
+                    )]
+                    public partial record TestRecord(string Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MultipleNamedArguments_TargetsSeparatorCorrectly()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey(
+                        "User_{UserId}_{TenantId}",
+                        InvariantCulture = false,
+                        {|COMPOSITE0006:PrimaryKeySeparator = '|'|}
+                    )]
+                    public partial record UserKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Tests for edge cases and integration scenarios.
+    /// </summary>
+    public class EdgeCasesAndIntegration
+    {
+        [Fact]
+        public async Task RecordWithoutAttribute_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    public partial record UserKey(string UserId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MultipleTypesWithDifferentTemplateIssues()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    // Valid template
+                    [CompositeKey("User_{UserId}")]
+                    public partial record UserKey(string UserId);
+
+                    // Empty template error
+                    [CompositeKey({|COMPOSITE0005:""|})]
+                    public partial record EmptyKey(string Id);
+
+                    // Missing separator error
+                    [CompositeKey("Product_{ProductId}_{Version}", {|COMPOSITE0006:PrimaryKeySeparator = '|'|})]
+                    public partial record ProductKey(string ProductId, int Version);
+
+                    // Valid composite key
+                    [CompositeKey("Order_{OrderId}|{CustomerId}", PrimaryKeySeparator = '|')]
+                    public partial record OrderKey(string OrderId, string CustomerId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task NestedTypes_HandlesCorrectly()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    public partial class Container
+                    {
+                        [CompositeKey({|COMPOSITE0005:""|})]
+                        public partial record EmptyKey(string Id);
+
+                        [CompositeKey("Valid_{Id}")]
+                        public partial record ValidKey(string Id);
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task GenericTypes_HandlesCorrectly()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{Id}")]
+                    public partial record EntityKey<T>(string Id, T Data);
+
+                    [CompositeKey({|COMPOSITE0005:""|})]
+                    public partial record EmptyGenericKey<T>(T Value);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ComplexRealWorldTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+                    using System;
+
+                    [CompositeKey("ORD_{Year:0000}_{Month:00}_{Day:00}#{OrderNumber:000000}_{CustomerId}", PrimaryKeySeparator = '#')]
+                    public partial record OrderIdentifier(
+                        int Year,
+                        int Month,
+                        int Day,
+                        int OrderNumber,
+                        Guid CustomerId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task SpecialCharactersInTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("@{Type}!{Id}~{Version}")]
+                    public partial record SpecialKey(string Type, string Id, int Version);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task UnicodeCharactersInTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("用户_{UserId}_租户_{TenantId}")]
+                    public partial record InternationalKey(string UserId, string TenantId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithComplexFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+                    using System;
+
+                    [CompositeKey("{Date:yyyy-MM-dd_HH-mm-ss}_{Counter:D10}")]
+                    public partial record TestKey(DateTime Date, int Counter);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithMixedCaseProperties_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{ID}_{UserName}_{GUID}")]
+                    public partial record TestKey(string ID, string UserName, string GUID);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TemplateWithLongPropertyNames_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new TemplateStringAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("{VeryLongPropertyNameThatExceedsNormalLength}_{AnotherLongPropertyName}")]
+                    public partial record TestKey(
+                        string VeryLongPropertyNameThatExceedsNormalLength,
+                        string AnotherLongPropertyName);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Tests for analyzer public API and metadata.
+    /// </summary>
+    public class AnalyzerApiTests
+    {
+        [Fact]
+        public void TemplateStringAnalyzer_SupportsExpectedDiagnostics()
+        {
+            // Arrange
+            var analyzer = new TemplateStringAnalyzer();
+
+            // Act
+            var supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+            // Assert
+            supportedDiagnostics.ShouldNotBeEmpty();
+            supportedDiagnostics.Length.ShouldBe(2);
+
+            var diagnosticIds = supportedDiagnostics.Select(d => d.Id).ToList();
+            diagnosticIds.ShouldContain("COMPOSITE0005"); // EmptyOrInvalidTemplateString
+            diagnosticIds.ShouldContain("COMPOSITE0006"); // PrimaryKeySeparatorMissingFromTemplateString
+        }
+
+        [Fact]
+        public void TemplateStringAnalyzer_DiagnosticsHaveCorrectSeverity()
+        {
+            // Arrange
+            var analyzer = new TemplateStringAnalyzer();
+
+            // Act
+            var supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+            // Assert
+            foreach (var diagnostic in supportedDiagnostics)
+            {
+                diagnostic.DefaultSeverity.ShouldBe(DiagnosticSeverity.Error);
+                diagnostic.IsEnabledByDefault.ShouldBeTrue();
+            }
+        }
+
+        [Fact]
+        public void TemplateStringAnalyzer_DiagnosticsHaveCorrectCategory()
+        {
+            // Arrange
+            var analyzer = new TemplateStringAnalyzer();
+
+            // Act
+            var supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+            // Assert
+            foreach (var diagnostic in supportedDiagnostics)
+            {
+                diagnostic.Category.ShouldBe("CompositeKey.SourceGeneration");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Test helper class for TemplateStringAnalyzer tests.
+    /// </summary>
+    private class TemplateStringAnalyzerTest : CompositeKeyAnalyzerTestBase<TemplateStringAnalyzer>;
+}

--- a/src/CompositeKey.Analyzers.UnitTests/Infrastructure/CompositeKeyAnalyzerTestBase.cs
+++ b/src/CompositeKey.Analyzers.UnitTests/Infrastructure/CompositeKeyAnalyzerTestBase.cs
@@ -1,5 +1,3 @@
-using CompositeKey.Analyzers.Common.Diagnostics;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/CompositeKey.Analyzers/Analyzers/TemplateStringAnalyzer.cs
+++ b/src/CompositeKey.Analyzers/Analyzers/TemplateStringAnalyzer.cs
@@ -1,0 +1,235 @@
+using System.Collections.Immutable;
+using CompositeKey.Analyzers.Common.Diagnostics;
+using CompositeKey.Analyzers.Common.Validation;
+using CompositeKey.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CompositeKey.Analyzers.Analyzers;
+
+/// <summary>
+/// Analyzer that validates template string format and primary key separator requirements
+/// for CompositeKey-annotated types in real-time.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class TemplateStringAnalyzer : CompositeKeyAnalyzerBase
+{
+    /// <summary>
+    /// Gets the supported diagnostics for template string validation.
+    /// </summary>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+        DiagnosticDescriptors.PrimaryKeySeparatorMissingFromTemplateString);
+
+    /// <summary>
+    /// Analyzes a CompositeKey-annotated type for template string requirements.
+    /// </summary>
+    /// <param name="context">The syntax node analysis context.</param>
+    /// <param name="typeDeclaration">The type declaration being analyzed.</param>
+    /// <param name="typeSymbol">The symbol for the type declaration.</param>
+    /// <param name="compositeKeyAttribute">The CompositeKey attribute data.</param>
+    protected override void AnalyzeCompositeKeyType(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        INamedTypeSymbol typeSymbol,
+        AttributeData? compositeKeyAttribute)
+    {
+        if (compositeKeyAttribute is null)
+            return;
+
+        var templateString = ExtractTemplateString(compositeKeyAttribute);
+        if (templateString is null)
+        {
+            ReportEmptyOrInvalidTemplate(context, typeDeclaration, string.Empty);
+            return;
+        }
+
+        var basicValidation = TemplateValidation.ValidateTemplateString(templateString);
+        if (!basicValidation.IsSuccess)
+        {
+            ReportTemplateValidationError(context, typeDeclaration, basicValidation, templateString);
+            return;
+        }
+
+        var primaryKeySeparator = ExtractPrimaryKeySeparator(compositeKeyAttribute);
+
+        var tokenizationResult = TemplateValidation.TokenizeTemplateString(templateString, primaryKeySeparator);
+        if (!tokenizationResult.Success)
+        {
+            ReportEmptyOrInvalidTemplate(context, typeDeclaration, templateString);
+            return;
+        }
+
+        if (!TemplateValidation.HasValidTemplateStructure(tokenizationResult.Tokens))
+        {
+            ReportEmptyOrInvalidTemplate(context, typeDeclaration, templateString);
+            return;
+        }
+
+        if (primaryKeySeparator.HasValue)
+        {
+            var separatorValidation = TemplateValidation.ValidatePrimaryKeySeparator(
+                templateString,
+                primaryKeySeparator,
+                tokenizationResult.Tokens);
+
+            if (!separatorValidation.IsSuccess)
+            {
+                ReportSeparatorValidationError(context, typeDeclaration, separatorValidation);
+                return;
+            }
+
+            if (!TemplateValidation.ValidatePartitionAndSortKeyStructure(tokenizationResult.Tokens, out _))
+            {
+                ReportEmptyOrInvalidTemplate(context, typeDeclaration, templateString);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the template string from the CompositeKey attribute.
+    /// </summary>
+    private static string? ExtractTemplateString(AttributeData attributeData)
+    {
+        if (attributeData.ConstructorArguments.Length > 0)
+        {
+            var arg = attributeData.ConstructorArguments[0];
+            if (arg.Value is string templateString)
+            {
+                return templateString;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the PrimaryKeySeparator property value from the CompositeKey attribute.
+    /// </summary>
+    private static char? ExtractPrimaryKeySeparator(AttributeData attributeData)
+    {
+        foreach (var namedArgument in attributeData.NamedArguments)
+        {
+            if (namedArgument is { Key: "PrimaryKeySeparator", Value.Value: char separator })
+            {
+                return separator;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reports an empty or invalid template string diagnostic.
+    /// </summary>
+    private static void ReportEmptyOrInvalidTemplate(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        string templateString)
+    {
+        var location = GetTemplateStringLocation(typeDeclaration);
+
+        var diagnostic = Diagnostic.Create(
+            DiagnosticDescriptors.EmptyOrInvalidTemplateString,
+            location,
+            templateString);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
+    /// Reports a template validation error with precise location targeting.
+    /// </summary>
+    private static void ReportTemplateValidationError(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        TemplateValidation.TemplateValidationResult validationResult,
+        string templateString)
+    {
+        if (validationResult.IsSuccess || validationResult.Descriptor is null)
+            return;
+
+        var location = GetTemplateStringLocation(typeDeclaration);
+
+        var diagnostic = Diagnostic.Create(
+            validationResult.Descriptor,
+            location,
+            validationResult.MessageArgs ?? new[] { templateString });
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
+    /// Reports a separator validation error with precise location targeting.
+    /// </summary>
+    private static void ReportSeparatorValidationError(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        TemplateValidation.TemplateValidationResult validationResult)
+    {
+        if (validationResult.IsSuccess || validationResult.Descriptor is null)
+            return;
+
+        var location = GetPrimaryKeySeparatorLocation(typeDeclaration);
+
+        var diagnostic = Diagnostic.Create(
+            validationResult.Descriptor,
+            location,
+            validationResult.MessageArgs ?? []);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
+    /// Gets the location of the template string argument in the attribute.
+    /// </summary>
+    private static Location? GetTemplateStringLocation(TypeDeclarationSyntax typeDeclaration)
+    {
+        var attributeSyntax = FindAttributeSyntax(typeDeclaration);
+        if (attributeSyntax?.ArgumentList?.Arguments.Count > 0)
+        {
+            var templateArgument = attributeSyntax.ArgumentList.Arguments[0];
+            return templateArgument.Expression.GetLocation();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the location of the PrimaryKeySeparator property in the attribute.
+    /// </summary>
+    private static Location? GetPrimaryKeySeparatorLocation(TypeDeclarationSyntax typeDeclaration)
+    {
+        var attributeSyntax = FindAttributeSyntax(typeDeclaration);
+        if (attributeSyntax?.ArgumentList != null)
+        {
+            foreach (var argument in attributeSyntax.ArgumentList.Arguments)
+            {
+                if (argument.NameEquals?.Name.Identifier.Text == "PrimaryKeySeparator")
+                {
+                    return argument.GetLocation();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the attribute syntax node that corresponds to the attribute data.
+    /// </summary>
+    private static AttributeSyntax? FindAttributeSyntax(TypeDeclarationSyntax typeDeclaration)
+    {
+        foreach (var attribute in typeDeclaration.AttributeLists.SelectMany(al => al.Attributes))
+        {
+            var name = attribute.Name.ToString();
+            if (name.Contains("CompositeKey") || name.Contains("CompositeKeyAttribute"))
+            {
+                return attribute;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Updates the Roslyn Analyzer with new diagnostics to report more errors in near real-time in the IDE.

This commit adds support for detecting and reporting the following diagnostics;
- COMPOSITE0005 - Empty or invalid template string
- COMPOSITE0006 - Primary key separator missing from template string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added analyser that validates template strings and primary key separators with precise, location-aware diagnostics.
- Bug Fixes
  - Prevents multiple primary separators and improves handling of empty/whitespace templates, malformed braces, and invalid property references.
- Refactor
  - Centralised template validation across components for consistent behaviour and clearer error reporting.
- Tests
  - Added comprehensive test coverage for tokenisation, structure rules, separator handling, diagnostics, and edge cases.
- Chores
  - Removed unused imports and aligned internal namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->