### PR TITLE
feat: Expand analyzer rules to cover property constraints

### DIFF
--- a/src/CompositeKey.Analyzers.Common.UnitTests/Validation/PropertyValidationTests.cs
+++ b/src/CompositeKey.Analyzers.Common.UnitTests/Validation/PropertyValidationTests.cs
@@ -1,0 +1,551 @@
+using CompositeKey.Analyzers.Common.Diagnostics;
+using CompositeKey.Analyzers.Common.Validation;
+
+namespace CompositeKey.Analyzers.Common.UnitTests.Validation;
+
+public static class PropertyValidationTests
+{
+    public class PropertyAccessibilityValidation
+    {
+        [Fact]
+        public void PublicGetterAndSetter_ProducesNoErrors()
+        {
+            // Arrange
+            var property = new PropertyValidation.PropertyAccessibilityInfo(
+                Name: "TestProperty",
+                HasGetter: true,
+                HasSetter: true);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyAccessibility(property);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            result.Descriptor.ShouldBeNull();
+            result.MessageArgs.ShouldBeNull();
+        }
+
+        [Fact]
+        public void MissingGetter_ReportsAccessibilityError()
+        {
+            // Arrange
+            var property = new PropertyValidation.PropertyAccessibilityInfo(
+                Name: "TestProperty",
+                HasGetter: false,
+                HasSetter: true);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyAccessibility(property);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+        }
+
+        [Fact]
+        public void MissingSetter_ReportsAccessibilityError()
+        {
+            // Arrange
+            var property = new PropertyValidation.PropertyAccessibilityInfo(
+                Name: "TestProperty",
+                HasGetter: true,
+                HasSetter: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyAccessibility(property);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+        }
+
+        [Fact]
+        public void NoGetterOrSetter_ReportsAccessibilityError()
+        {
+            // Arrange
+            var property = new PropertyValidation.PropertyAccessibilityInfo(
+                Name: "TestProperty",
+                HasGetter: false,
+                HasSetter: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyAccessibility(property);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+        }
+    }
+
+    public class PropertyFormatValidation
+    {
+        [Theory]
+        [InlineData("d")]
+        [InlineData("n")]
+        [InlineData("b")]
+        [InlineData("p")]
+        [InlineData("x")]
+        [InlineData("D")]
+        [InlineData("N")]
+        [InlineData("B")]
+        [InlineData("P")]
+        [InlineData("X")]
+        public void ValidGuidFormat_ProducesNoErrors(string format)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, format);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("z")]
+        [InlineData("invalid")]
+        [InlineData("123")]
+        [InlineData("dd")]
+        public void InvalidGuidFormat_ReportsFormatError(string format)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, format);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+            result.MessageArgs[1].ShouldBe(format);
+        }
+
+        [Fact]
+        public void GuidWithNullFormat_ProducesNoErrors()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, null);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void StringWithNullFormat_ProducesNoErrors()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.String",
+                IsGuid: false,
+                IsString: true,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, null);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("d")]
+        [InlineData("n")]
+        [InlineData("anything")]
+        public void StringWithFormat_ReportsFormatError(string format)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.String",
+                IsGuid: false,
+                IsString: true,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, format);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+            result.MessageArgs[1].ShouldBe(format);
+        }
+
+        [Theory]
+        [InlineData("g")]
+        [InlineData("G")]
+        [InlineData(null)]
+        public void EnumWithValidFormat_ProducesNoErrors(string? format)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "MyEnum",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: true,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, format);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("d")]
+        [InlineData("x")]
+        [InlineData("f")]
+        [InlineData("invalid")]
+        public void EnumWithInvalidFormat_ReportsFormatError(string format)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "MyEnum",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: true,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, format);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+            result.MessageArgs.ShouldNotBeNull();
+            result.MessageArgs[0].ShouldBe("TestProperty");
+            result.MessageArgs[1].ShouldBe(format);
+        }
+
+        [Fact]
+        public void SpanFormattableType_WithAnyFormat_ProducesNoErrors()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.DateTime",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: true,
+                IsSpanFormattable: true);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyFormat("TestProperty", typeInfo, "yyyy-MM-dd");
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+    }
+
+    public class PropertyTypeCompatibilityValidation
+    {
+        [Fact]
+        public void GuidType_IsCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void StringType_IsCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.String",
+                IsGuid: false,
+                IsString: true,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void EnumType_IsCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "MyEnum",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: true,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void SpanParsableAndFormattableType_IsCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.DateTime",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: true,
+                IsSpanFormattable: true);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void OnlySpanParsableType_IsNotCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "CustomType",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: true,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+        }
+
+        [Fact]
+        public void OnlySpanFormattableType_IsNotCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "CustomType",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: true);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+        }
+
+        [Fact]
+        public void UnsupportedType_IsNotCompatible()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Object",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.ValidatePropertyTypeCompatibility("TestProperty", typeInfo);
+
+            // Assert
+            result.IsSuccess.ShouldBeFalse();
+            result.Descriptor.ShouldBe(DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+        }
+    }
+
+    public class FormattedLengthCalculation
+    {
+        [Theory]
+        [InlineData("d", 36, true)]
+        [InlineData("n", 32, true)]
+        [InlineData("b", 38, true)]
+        [InlineData("p", 38, true)]
+        [InlineData("x", 32, false)]
+        [InlineData("D", 36, true)]
+        [InlineData("N", 32, true)]
+        [InlineData("B", 38, true)]
+        [InlineData("P", 38, true)]
+        [InlineData("X", 32, false)]
+        [InlineData(null, 36, true)]
+        public void GuidFormattedLength_ReturnsCorrectValues(string? format, int expectedLength, bool expectedExact)
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, format);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Value.length.ShouldBe(expectedLength);
+            result.Value.isExact.ShouldBe(expectedExact);
+        }
+
+        [Fact]
+        public void StringFormattedLength_ReturnsMinimumOne()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.String",
+                IsGuid: false,
+                IsString: true,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, null);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Value.length.ShouldBe(1);
+            result.Value.isExact.ShouldBe(false);
+        }
+
+        [Fact]
+        public void EnumFormattedLength_ReturnsMinimumOne()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "MyEnum",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: true,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, "g");
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Value.length.ShouldBe(1);
+            result.Value.isExact.ShouldBe(false);
+        }
+
+        [Fact]
+        public void SpanFormattableFormattedLength_ReturnsMinimumOne()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.DateTime",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: true,
+                IsSpanFormattable: true);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, "yyyy-MM-dd");
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Value.length.ShouldBe(1);
+            result.Value.isExact.ShouldBe(false);
+        }
+
+        [Fact]
+        public void GuidWithInvalidFormat_ReturnsNull()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Guid",
+                IsGuid: true,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, "invalid");
+
+            // Assert
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void UnsupportedType_ReturnsNull()
+        {
+            // Arrange
+            var typeInfo = new PropertyValidation.PropertyTypeInfo(
+                TypeName: "System.Object",
+                IsGuid: false,
+                IsString: false,
+                IsEnum: false,
+                IsSpanParsable: false,
+                IsSpanFormattable: false);
+
+            // Act
+            var result = PropertyValidation.GetFormattedLength(typeInfo, null);
+
+            // Assert
+            result.ShouldBeNull();
+        }
+    }
+}

--- a/src/CompositeKey.Analyzers.Common/Validation/PropertyValidation.cs
+++ b/src/CompositeKey.Analyzers.Common/Validation/PropertyValidation.cs
@@ -1,0 +1,149 @@
+using System.Diagnostics.CodeAnalysis;
+using CompositeKey.Analyzers.Common.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace CompositeKey.Analyzers.Common.Validation;
+
+public static class PropertyValidation
+{
+    public record PropertyValidationResult
+    {
+        [MemberNotNullWhen(false, nameof(Descriptor), nameof(MessageArgs))]
+        public required bool IsSuccess { get; init; }
+
+        public DiagnosticDescriptor? Descriptor { get; init; }
+        public object?[]? MessageArgs { get; init; }
+
+        public static PropertyValidationResult Success() => new()
+        {
+            IsSuccess = true
+        };
+
+        public static PropertyValidationResult Failure(DiagnosticDescriptor descriptor, params object?[] messageArgs) => new()
+        {
+            IsSuccess = false,
+            Descriptor = descriptor,
+            MessageArgs = messageArgs
+        };
+    }
+
+    public record PropertyTypeInfo(
+        string TypeName,
+        bool IsGuid,
+        bool IsString,
+        bool IsEnum,
+        bool IsSpanParsable,
+        bool IsSpanFormattable);
+
+    public record PropertyAccessibilityInfo(
+        string Name,
+        bool HasGetter,
+        bool HasSetter);
+
+    /// <summary>
+    /// Validates that a property has accessible getter and setter.
+    /// </summary>
+    public static PropertyValidationResult ValidatePropertyAccessibility(PropertyAccessibilityInfo property)
+    {
+        if (!property.HasGetter || !property.HasSetter)
+        {
+            return PropertyValidationResult.Failure(
+                DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter,
+                property.Name);
+        }
+
+        return PropertyValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a property format specifier is compatible with the property type.
+    /// </summary>
+    public static PropertyValidationResult ValidatePropertyFormat(
+        string propertyName,
+        PropertyTypeInfo typeInfo,
+        string? formatSpecifier)
+    {
+        if (typeInfo.IsGuid && formatSpecifier != null)
+        {
+            string format = formatSpecifier.ToLowerInvariant();
+            if (format != "d" && format != "n" && format != "b" && format != "p" && format != "x")
+            {
+                return PropertyValidationResult.Failure(
+                    DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat,
+                    propertyName,
+                    formatSpecifier);
+            }
+        }
+
+        if (typeInfo.IsString && formatSpecifier != null)
+        {
+            return PropertyValidationResult.Failure(
+                DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat,
+                propertyName,
+                formatSpecifier);
+        }
+
+        if (typeInfo.IsEnum && formatSpecifier != null)
+        {
+            string format = formatSpecifier.ToLowerInvariant();
+            if (format != "g")
+            {
+                return PropertyValidationResult.Failure(
+                    DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat,
+                    propertyName,
+                    formatSpecifier);
+            }
+        }
+
+        return PropertyValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a property type is compatible with CompositeKey requirements.
+    /// </summary>
+    public static PropertyValidationResult ValidatePropertyTypeCompatibility(
+        string propertyName,
+        PropertyTypeInfo typeInfo)
+    {
+        bool isSupported = typeInfo.IsGuid ||
+                          typeInfo.IsString ||
+                          typeInfo.IsEnum ||
+                          typeInfo is { IsSpanParsable: true, IsSpanFormattable: true };
+
+        if (!isSupported)
+        {
+            return PropertyValidationResult.Failure(
+                DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat,
+                propertyName,
+                "Type is not supported");
+        }
+
+        return PropertyValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Gets the required length for a formatted property value.
+    /// </summary>
+    public static (int length, bool isExact)? GetFormattedLength(PropertyTypeInfo typeInfo, string? formatSpecifier)
+    {
+        if (typeInfo.IsGuid)
+        {
+            string format = formatSpecifier?.ToLowerInvariant() ?? "d";
+            return format switch
+            {
+                "d" => (36, true),
+                "n" => (32, true),
+                "b" or "p" => (38, true),
+                "x" => (32, false),
+                _ => null
+            };
+        }
+
+        if (typeInfo.IsString || typeInfo.IsEnum || typeInfo is { IsSpanParsable: true, IsSpanFormattable: true })
+        {
+            return (1, false);
+        }
+
+        return null;
+    }
+}

--- a/src/CompositeKey.Analyzers.Common/Validation/TemplateValidation.cs
+++ b/src/CompositeKey.Analyzers.Common/Validation/TemplateValidation.cs
@@ -65,11 +65,24 @@ public static class TemplateValidation
         foreach (var token in propertyTokens)
         {
             var property = availableProperties.FirstOrDefault(p => p.Name == token.Name);
-            if (property == null || !property.HasGetter || !property.HasSetter)
+            if (property == null)
             {
                 return TemplateValidationResult.Failure(
                     DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter,
                     token.Name);
+            }
+
+            var accessibilityInfo = new PropertyValidation.PropertyAccessibilityInfo(
+                property.Name,
+                property.HasGetter,
+                property.HasSetter);
+
+            var accessibilityResult = PropertyValidation.ValidatePropertyAccessibility(accessibilityInfo);
+            if (!accessibilityResult.IsSuccess)
+            {
+                return TemplateValidationResult.Failure(
+                    accessibilityResult.Descriptor,
+                    accessibilityResult.MessageArgs);
             }
         }
 

--- a/src/CompositeKey.Analyzers.UnitTests/Analyzers/PropertyAnalyzerTests.cs
+++ b/src/CompositeKey.Analyzers.UnitTests/Analyzers/PropertyAnalyzerTests.cs
@@ -1,0 +1,565 @@
+using CompositeKey.Analyzers.Analyzers;
+using CompositeKey.Analyzers.UnitTests.Infrastructure;
+
+namespace CompositeKey.Analyzers.UnitTests.Analyzers;
+
+/// <summary>
+/// Comprehensive tests for PropertyAnalyzer validating property accessibility and format specifiers
+/// for CompositeKey-annotated types including location precision verification.
+/// </summary>
+public static class PropertyAnalyzerTests
+{
+    /// <summary>
+    /// Tests for property accessibility validation (COMPOSITE0007).
+    /// </summary>
+    public class PropertyAccessibilityValidation
+    {
+        [Fact]
+        public async Task PublicGetterAndSetter_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{UserId}")]
+                    public partial record UserKey(string UserId);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyWithPrivateGetter_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{UserId}")]
+                    public partial record UserKey
+                    {
+                        public string UserId { private get; set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyWithPrivateSetter_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Item_{ItemId}")]
+                    public partial record ItemKey
+                    {
+                        public string ItemId { get; private set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyWithProtectedSetter_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Order_{OrderId}")]
+                    public partial record OrderKey
+                    {
+                        public string OrderId { get; protected set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyWithInitOnlySetter_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Product_{ProductId}")]
+                    public partial record ProductKey
+                    {
+                        public string ProductId { get; init; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ReadOnlyProperty_ReportsAccessibilityError()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{EntityId}")]
+                    public partial record EntityKey
+                    {
+                        private readonly string _entityId = "";
+                        public string {|COMPOSITE0007:EntityId|} { get { return _entityId; } }
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyWithNoGetter_ReportsAccessibilityError()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("Composite_{WriteOnly}")]
+                    public partial record CompositeKeyRecord
+                    {
+                        private string _writeOnly = "";
+                        public string {|COMPOSITE0007:WriteOnly|} { set { _writeOnly = value; } }
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyNotReferencedInTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{UserId}")]
+                    public partial record UserKey
+                    {
+                        public string UserId { get; set; } = "";
+                        public string UnusedProp { get; private set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task InheritedProperties_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    public record BaseRecord
+                    {
+                        public string BaseId { get; private set; } = "";
+                    }
+
+                    [CompositeKey("Derived_{DerivedId}")]
+                    public partial record DerivedKey : BaseRecord
+                    {
+                        public string DerivedId { get; set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task EmptyTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("")]
+                    public partial record EmptyKey
+                    {
+                        public string Id { private get; set; } = "";
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Tests for property format validation (COMPOSITE0008).
+    /// </summary>
+    public class PropertyFormatValidation
+    {
+        [Fact]
+        public async Task GuidWithValidFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{Id:D}")]
+                    public partial record EntityKey(Guid Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("d")]
+        [InlineData("n")]
+        [InlineData("b")]
+        [InlineData("p")]
+        [InlineData("x")]
+        public async Task GuidWithAllValidFormats_ProducesNoDiagnostics(string format)
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = $$"""
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{Id:{{format}}}")]
+                    public partial record EntityKey(Guid Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task GuidWithCaseInsensitiveFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{Id:D}")]
+                    public partial record EntityKey(Guid Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task GuidWithInvalidFormat_ReportsFormatError()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{Id:invalid}")]
+                    public partial record EntityKey(Guid {|COMPOSITE0008:Id|});
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task StringWithFormat_ReportsFormatError()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{Name:upper}")]
+                    public partial record UserKey(string {|COMPOSITE0008:Name|});
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task StringWithoutFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    [CompositeKey("User_{Name}")]
+                    public partial record UserKey(string Name);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task EnumWithValidFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    public enum Status { Active, Inactive }
+
+                    [CompositeKey("Entity_{CurrentStatus:g}")]
+                    public partial record EntityKey(Status CurrentStatus);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task EnumWithInvalidFormat_ReportsFormatError()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using CompositeKey;
+
+                    public enum Status { Active, Inactive }
+
+                    [CompositeKey("Entity_{CurrentStatus:d}")]
+                    public partial record EntityKey(Status {|COMPOSITE0008:CurrentStatus|});
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task DateTimeWithFormat_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Log_{Timestamp:yyyy-MM-dd}")]
+                    public partial record LogKey(DateTime Timestamp);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MultiplePropertiesWithFormatIssues_ReportsMultipleDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Mixed_{Id:invalid}_{Name:upper}")]
+                    public partial record MixedKey(Guid {|COMPOSITE0008:Id|}, string {|COMPOSITE0008:Name|});
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ComplexPropertyTypes_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Complex_{Id:d}_{Timestamp:yyyy-MM-dd}_{Status:g}")]
+                    public partial record ComplexKey(Guid Id, DateTime Timestamp, DayOfWeek Status);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ConstantsInTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("CONST_{Id}")]
+                    public partial record EntityKey(Guid Id);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Tests for composite primary key scenarios with property validation.
+    /// </summary>
+    public class CompositePrimaryKeyScenarios
+    {
+        [Fact]
+        public async Task CompositePrimaryKey_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("PK_{PartitionKey}#SK_{SortKey}", PrimaryKeySeparator = '#')]
+                    public partial record CompositeRecord(string PartitionKey, Guid SortKey);
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CompositePrimaryKey_WithPrivateAccessors_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("PK_{PartitionKey}#SK_{SortKey}", PrimaryKeySeparator = '#')]
+                    public partial record CompositeRecord
+                    {
+                        public string PartitionKey { private get; set; } = "";
+                        public Guid SortKey { get; private set; }
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task CompositePrimaryKey_ReportsFormatIssues()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("PK_{PartitionKey:format}#SK_{SortKey:invalid}", PrimaryKeySeparator = '#')]
+                    public partial record CompositeRecord(string {|COMPOSITE0008:PartitionKey|}, Guid {|COMPOSITE0008:SortKey|});
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PropertyNotInTemplate_ProducesNoDiagnostics()
+        {
+            // Arrange
+            var test = new PropertyAnalyzerTest
+            {
+                TestCode = """
+                    using System;
+                    using CompositeKey;
+
+                    [CompositeKey("Entity_{NonExistent}")]
+                    public partial record EntityKey
+                    {
+                        public Guid Id { get; set; }
+                    }
+                    """
+            };
+
+            // Act & Assert
+            await test.RunAsync();
+        }
+    }
+
+    /// <summary>
+    /// Test fixture for PropertyAnalyzer using the analyzer test infrastructure.
+    /// </summary>
+    private sealed class PropertyAnalyzerTest : CompositeKeyAnalyzerTestBase<PropertyAnalyzer>;
+}

--- a/src/CompositeKey.Analyzers.UnitTests/Analyzers/TemplateStringAnalyzerTests.cs
+++ b/src/CompositeKey.Analyzers.UnitTests/Analyzers/TemplateStringAnalyzerTests.cs
@@ -8,7 +8,7 @@ namespace CompositeKey.Analyzers.UnitTests.Analyzers;
 /// Comprehensive tests for TemplateStringAnalyzer validating template string format,
 /// primary key separator requirements, and precise diagnostic location targeting.
 /// </summary>
-public class TemplateStringAnalyzerTests
+public static class TemplateStringAnalyzerTests
 {
     /// <summary>
     /// Tests for template format validation (COMPOSITE0005).

--- a/src/CompositeKey.Analyzers.UnitTests/Analyzers/TypeStructureAnalyzerTests.cs
+++ b/src/CompositeKey.Analyzers.UnitTests/Analyzers/TypeStructureAnalyzerTests.cs
@@ -7,7 +7,7 @@ namespace CompositeKey.Analyzers.UnitTests.Analyzers;
 /// Comprehensive tests for TypeStructureAnalyzer validating type structure requirements
 /// for CompositeKey-annotated types including location precision verification.
 /// </summary>
-public class TypeStructureAnalyzerTests
+public static class TypeStructureAnalyzerTests
 {
     /// <summary>
     /// Tests for supported type validation (COMPOSITE0002).
@@ -255,7 +255,7 @@ public class TypeStructureAnalyzerTests
                     public partial record UserKey
                     {
                         public string UserId { get; set; }
-                        
+
                         public UserKey(string userId)
                         {
                             UserId = userId;
@@ -281,11 +281,11 @@ public class TypeStructureAnalyzerTests
                     public partial record UserKey
                     {
                         public string UserId { get; set; }
-                        
+
                         private UserKey()
                         {
                         }
-                        
+
                         private UserKey(string userId)
                         {
                             UserId = userId;
@@ -311,7 +311,7 @@ public class TypeStructureAnalyzerTests
                     public partial record UserKey
                     {
                         public string UserId { get; set; }
-                        
+
                         public UserKey()
                         {
                         }
@@ -336,12 +336,12 @@ public class TypeStructureAnalyzerTests
                     public partial record UserKey
                     {
                         public string UserId { get; set; }
-                        
+
                         public UserKey(string userId)
                         {
                             UserId = userId;
                         }
-                        
+
                         private UserKey()
                         {
                         }
@@ -740,11 +740,11 @@ public class TypeStructureAnalyzerTests
                         public string DisplayName { get; init; } = "";
                         public DateTime CreatedAt { get; init; } = DateTime.Now;
                         public List<string> Tags { get; init; } = new();
-                        
+
                         // Methods
                         public string GetFullKey() => $"{Id}_{Type}_{Version:000}";
                         public override string ToString() => GetFullKey();
-                        
+
                         // Static members
                         public static ComplexKey CreateDefault(string id) => new(id, "default", 1);
                     }
@@ -815,7 +815,7 @@ public class TypeStructureAnalyzerTests
             // Assert
             supportedDiagnostics.ShouldNotBeEmpty();
             supportedDiagnostics.Length.ShouldBe(3);
-            
+
             var diagnosticIds = supportedDiagnostics.Select(d => d.Id).ToList();
             diagnosticIds.ShouldContain("COMPOSITE0002"); // UnsupportedCompositeType
             diagnosticIds.ShouldContain("COMPOSITE0003"); // CompositeTypeMustBePartial

--- a/src/CompositeKey.Analyzers/Analyzers/PropertyAnalyzer.cs
+++ b/src/CompositeKey.Analyzers/Analyzers/PropertyAnalyzer.cs
@@ -1,0 +1,229 @@
+using System.Collections.Immutable;
+using CompositeKey.Analyzers.Common.Diagnostics;
+using CompositeKey.Analyzers.Common.Tokenization;
+using CompositeKey.Analyzers.Common.Validation;
+using CompositeKey.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CompositeKey.Analyzers.Analyzers;
+
+/// <summary>
+/// Analyzer that validates property accessibility and format specifiers for CompositeKey-annotated types.
+/// Reports diagnostics for properties that lack accessible getters/setters or have invalid format specifiers.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PropertyAnalyzer : CompositeKeyAnalyzerBase
+{
+    /// <summary>
+    /// Gets the supported diagnostics for property validation.
+    /// </summary>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        DiagnosticDescriptors.PropertyMustHaveAccessibleGetterAndSetter,
+        DiagnosticDescriptors.PropertyHasInvalidOrUnsupportedFormat);
+
+    /// <summary>
+    /// Analyzes properties referenced in a CompositeKey template string.
+    /// </summary>
+    /// <param name="context">The syntax node analysis context.</param>
+    /// <param name="typeDeclaration">The type declaration being analyzed.</param>
+    /// <param name="typeSymbol">The symbol for the type declaration.</param>
+    /// <param name="compositeKeyAttribute">The CompositeKey attribute data.</param>
+    protected override void AnalyzeCompositeKeyType(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        INamedTypeSymbol typeSymbol,
+        AttributeData? compositeKeyAttribute)
+    {
+        if (compositeKeyAttribute is null)
+            return;
+
+        var templateString = GetTemplateString(compositeKeyAttribute);
+        if (string.IsNullOrWhiteSpace(templateString))
+            return;
+
+        var primaryKeySeparator = GetPrimaryKeySeparator(compositeKeyAttribute);
+
+        var tokenizer = new TemplateStringTokenizer(primaryKeySeparator);
+        var tokenizationResult = tokenizer.Tokenize(templateString.AsSpan());
+        if (!tokenizationResult.Success)
+            return;
+
+        var properties = GetTypeProperties(typeSymbol);
+
+        foreach (var token in tokenizationResult.Tokens)
+        {
+            if (token is not PropertyTemplateToken propertyToken)
+                continue;
+
+            var property = properties.FirstOrDefault(p => p.Name == propertyToken.Name);
+            if (property is null)
+                continue; // Property not found is handled by template validation
+
+            var accessibilityInfo = new PropertyValidation.PropertyAccessibilityInfo(
+                Name: property.Name,
+                HasGetter: property.GetMethod is not null,
+                HasSetter: property.SetMethod is not null);
+
+            var accessibilityResult = PropertyValidation.ValidatePropertyAccessibility(accessibilityInfo);
+            if (!accessibilityResult.IsSuccess)
+            {
+                ReportPropertyDiagnostic(
+                    context,
+                    typeDeclaration,
+                    property,
+                    accessibilityResult);
+            }
+
+            var typeInfo = CreatePropertyTypeInfo(property, context.Compilation);
+
+            if (!string.IsNullOrEmpty(propertyToken.Format))
+            {
+                var formatResult = PropertyValidation.ValidatePropertyFormat(
+                    property.Name,
+                    typeInfo,
+                    propertyToken.Format);
+
+                if (!formatResult.IsSuccess)
+                {
+                    ReportPropertyDiagnostic(
+                        context,
+                        typeDeclaration,
+                        property,
+                        formatResult);
+                }
+            }
+
+            var typeCompatibilityResult = PropertyValidation.ValidatePropertyTypeCompatibility(
+                property.Name,
+                typeInfo);
+
+            if (!typeCompatibilityResult.IsSuccess)
+            {
+                ReportPropertyDiagnostic(
+                    context,
+                    typeDeclaration,
+                    property,
+                    typeCompatibilityResult);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the template string from the CompositeKey attribute.
+    /// </summary>
+    private static string? GetTemplateString(AttributeData attributeData)
+    {
+        if (attributeData.ConstructorArguments.Length > 0)
+        {
+            var arg = attributeData.ConstructorArguments[0];
+            if (arg.Value is string templateString)
+                return templateString;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the primary key separator from the CompositeKey attribute.
+    /// </summary>
+    private static char? GetPrimaryKeySeparator(AttributeData attributeData)
+    {
+        var separatorArg = attributeData.NamedArguments
+            .FirstOrDefault(arg => arg.Key == "PrimaryKeySeparator");
+
+        if (separatorArg.Value.Value is char separator)
+            return separator;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets all properties from a type symbol.
+    /// </summary>
+    private static ImmutableArray<IPropertySymbol> GetTypeProperties(INamedTypeSymbol typeSymbol)
+    {
+        return typeSymbol.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(p => !p.IsStatic && !p.IsImplicitlyDeclared)
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Creates PropertyTypeInfo from a property symbol for validation.
+    /// </summary>
+    private static PropertyValidation.PropertyTypeInfo CreatePropertyTypeInfo(
+        IPropertySymbol property,
+        Compilation compilation)
+    {
+        var guidType = compilation.GetTypeByMetadataName("System.Guid");
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var isGuid = SymbolEqualityComparer.Default.Equals(property.Type, guidType);
+        var isString = SymbolEqualityComparer.Default.Equals(property.Type, stringType);
+        var isEnum = property.Type.TypeKind == TypeKind.Enum;
+
+        var interfaces = property.Type.AllInterfaces;
+        var isSpanParsable = interfaces.Any(i => i.ToDisplayString().StartsWith("System.ISpanParsable", StringComparison.Ordinal));
+        var isSpanFormattable = interfaces.Any(i => i.ToDisplayString().Equals("System.ISpanFormattable", StringComparison.Ordinal));
+
+        return new PropertyValidation.PropertyTypeInfo(
+            TypeName: property.Type.ToDisplayString(),
+            IsGuid: isGuid,
+            IsString: isString,
+            IsEnum: isEnum,
+            IsSpanParsable: isSpanParsable,
+            IsSpanFormattable: isSpanFormattable);
+    }
+
+    /// <summary>
+    /// Reports a diagnostic for a property validation issue with precise location targeting.
+    /// </summary>
+    private static void ReportPropertyDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        TypeDeclarationSyntax typeDeclaration,
+        IPropertySymbol property,
+        PropertyValidation.PropertyValidationResult validationResult)
+    {
+        if (validationResult.IsSuccess || validationResult.Descriptor is null)
+            return;
+
+        var location = GetPropertyLocation(typeDeclaration, property) ?? typeDeclaration.Identifier.GetLocation();
+        var diagnostic = Diagnostic.Create(
+            validationResult.Descriptor,
+            location,
+            validationResult.MessageArgs ?? []);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
+    /// Gets the precise location of a property declaration.
+    /// </summary>
+    private static Location? GetPropertyLocation(
+        TypeDeclarationSyntax typeDeclaration,
+        IPropertySymbol property)
+    {
+        var propertyDeclaration = typeDeclaration.Members
+            .OfType<PropertyDeclarationSyntax>()
+            .FirstOrDefault(p => p.Identifier.Text == property.Name);
+
+        if (propertyDeclaration != null)
+        {
+            return propertyDeclaration.Identifier.GetLocation();
+        }
+
+        if (typeDeclaration is RecordDeclarationSyntax { ParameterList: not null } recordDeclaration)
+        {
+            var parameter = recordDeclaration.ParameterList.Parameters
+                .FirstOrDefault(p => p.Identifier.Text == property.Name);
+
+            if (parameter != null)
+            {
+                return parameter.Identifier.GetLocation();
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Updates the Roslyn Analyzer with new diagnostics to report more errors in near real-time in the IDE.

This commit adds support for detecting and reporting the following diagnostics;
- COMPOSITE0007 - Property must have accessible getter and setter
- COMPOSITE0008 - Property has invalid or unsupported format string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds a PropertyAnalyzer and a shared PropertyValidation utility to validate property accessibility, type compatibility and format usage in CompositeKey templates; unified handling for Guid, string, enum and span-parsable/formattable types.
- Bug Fixes
  - More precise diagnostic locations and consistent diagnostics for format/accessibility issues; standardised formatted-length and default-format behaviour across analysis and generation.
- Tests
  - Adds extensive unit tests covering property validation, analyzer scenarios and template/type suites; several test containers made static.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->