### PR TITLE
feat: Add partial key formatting methods

### DIFF
--- a/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
@@ -37,6 +37,43 @@ public static class CompositePrimaryKeyTests
         result.ShouldBe($"{guidValue}#{decimalValue}");
     }
 
+    [Theory]
+    [InlineAutoData(0, false)]
+    [InlineAutoData(0, true)]
+    [InlineAutoData(1, false)]
+    public static void CompositePrimaryKey_ToPartitionKeyString_WithSpecificPartIndexAndDelimiterRequirements_ShouldReturnCorrectlyFormattedString(
+            int throughPartIndex, bool includeTrailingDelimiter, CompositePrimaryKey compositeKey)
+    {
+        (var guidValue, decimal decimalValue, _, _) = compositeKey;
+
+        string result = compositeKey.ToPartitionKeyString(throughPartIndex, includeTrailingDelimiter);
+
+        result.ShouldNotBeNullOrEmpty();
+
+        switch (throughPartIndex)
+        {
+            case 0 when !includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}");
+                break;
+            case 0 when includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#");
+                break;
+            case 1:
+                result.ShouldBe($"{guidValue}#{decimalValue}");
+                break;
+        }
+    }
+
+    [Theory]
+    [InlineAutoData(1, true)]
+    [InlineAutoData(2, false)]
+    public static void CompositePrimaryKey_ToPartitionKeyString_WithInvalidPartIndexOrDelimiterRequirements_ShouldThrowInvalidOperationException(
+        int throughPartIndex, bool includeTrailingDelimiter, CompositePrimaryKey compositeKey)
+    {
+        var act = () => compositeKey.ToPartitionKeyString(throughPartIndex, includeTrailingDelimiter);
+        act.ShouldThrow<InvalidOperationException>();
+    }
+
     [Theory, AutoData]
     public static void CompositePrimaryKey_ToSortKeyString_ShouldReturnCorrectlyFormattedString(CompositePrimaryKey compositeKey)
     {
@@ -46,6 +83,51 @@ public static class CompositePrimaryKeyTests
 
         result.ShouldNotBeNullOrEmpty();
         result.ShouldBe($"Constant~{enumValue}@{stringValue}");
+    }
+
+    [Theory]
+    [InlineAutoData(0, false)]
+    [InlineAutoData(0, true)]
+    [InlineAutoData(1, false)]
+    [InlineAutoData(1, true)]
+    [InlineAutoData(2, false)]
+    public static void CompositePrimaryKey_ToSortKeyString_WithSpecificPartIndexAndDelimiterRequirements_ShouldReturnCorrectlyFormattedString(
+        int throughPartIndex, bool includeTrailingDelimiter, CompositePrimaryKey compositeKey)
+    {
+        (_, _, var enumValue, string stringValue) = compositeKey;
+
+        string result = compositeKey.ToSortKeyString(throughPartIndex, includeTrailingDelimiter);
+
+        result.ShouldNotBeNullOrEmpty();
+
+        switch (throughPartIndex)
+        {
+            case 0 when !includeTrailingDelimiter:
+                result.ShouldBe($"Constant");
+                break;
+            case 0 when includeTrailingDelimiter:
+                result.ShouldBe($"Constant~");
+                break;
+            case 1 when !includeTrailingDelimiter:
+                result.ShouldBe($"Constant~{enumValue}");
+                break;
+            case 1 when includeTrailingDelimiter:
+                result.ShouldBe($"Constant~{enumValue}@");
+                break;
+            case 2:
+                result.ShouldBe($"Constant~{enumValue}@{stringValue}");
+                break;
+        }
+    }
+
+    [Theory]
+    [InlineAutoData(2, true)]
+    [InlineAutoData(3, false)]
+    public static void CompositePrimaryKey_ToSortKeyString_WithInvalidPartIndexOrDelimiterRequirements_ShouldThrowInvalidOperationException(
+        int throughPartIndex, bool includeTrailingDelimiter, CompositePrimaryKey compositeKey)
+    {
+        var act = () => compositeKey.ToSortKeyString(throughPartIndex, includeTrailingDelimiter);
+        act.ShouldThrow<InvalidOperationException>();
     }
 
     [Theory, AutoData]

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
@@ -275,5 +275,58 @@ public static class PrimaryKeyTests
         result.ShouldBe($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
     }
 
+    [Theory]
+    [InlineAutoData(0, false)]
+    [InlineAutoData(0, true)]
+    [InlineAutoData(1, false)]
+    [InlineAutoData(1, true)]
+    [InlineAutoData(2, false)]
+    [InlineAutoData(2, true)]
+    [InlineAutoData(3, false)]
+    public static void PrimaryKeyWithFastPathFormatting_ToPartitionKeyString_WithSpecificPartIndexAndDelimiterRequirements_ShouldReturnCorrectlyFormattedString(
+        int throughPartIndex, bool includeTrailingDelimiter, PrimaryKeyWithFastPathFormatting compositeKey)
+    {
+        (var guidValue, var enumValue, string stringValue) = compositeKey;
+
+        string result = compositeKey.ToPartitionKeyString(throughPartIndex, includeTrailingDelimiter);
+
+        result.ShouldNotBeNullOrEmpty();
+
+        switch (throughPartIndex)
+        {
+            case 0 when !includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}");
+                break;
+            case 0 when includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#");
+                break;
+            case 1 when !includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#Constant");
+                break;
+            case 1 when includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#Constant#");
+                break;
+            case 2 when !includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#Constant#{enumValue}");
+                break;
+            case 2 when includeTrailingDelimiter:
+                result.ShouldBe($"{guidValue}#Constant#{enumValue}@");
+                break;
+            case 3:
+                result.ShouldBe($"{guidValue}#Constant#{enumValue}@{stringValue}");
+                break;
+        }
+    }
+
+    [Theory]
+    [InlineAutoData(3, true)]
+    [InlineAutoData(4, false)]
+    public static void PrimaryKeyWithFastPathFormatting_ToPartitionKeyString_WithInvalidPartIndexOrDelimiterRequirements_ShouldThrowInvalidOperationException(
+        int throughPartIndex, bool includeTrailingDelimiter, PrimaryKeyWithFastPathFormatting compositeKey)
+    {
+        var act = () => compositeKey.ToPartitionKeyString(throughPartIndex, includeTrailingDelimiter);
+        act.ShouldThrow<InvalidOperationException>();
+    }
+
     #endregion
 }

--- a/src/CompositeKey/ICompositePrimaryKey`1.cs
+++ b/src/CompositeKey/ICompositePrimaryKey`1.cs
@@ -15,6 +15,22 @@ public interface ICompositePrimaryKey<TSelf> : IPrimaryKey<TSelf> where TSelf : 
     string ToSortKeyString();
 
     /// <summary>
+    /// Formats the sort key portion of the current instance to a string through the specified index.
+    /// </summary>
+    /// <param name="throughPartIndex">The zero-based index of the key part to format through (inclusive). This counts only properties and constants, not delimiters.</param>
+    /// <param name="includeTrailingDelimiter">Whether to include the following delimiter character in the formatted string, defaults to true.</param>
+    /// <returns>The sort key portion of the current instance up to the specified index formatted to a string.</returns>
+    /// <example>
+    /// For a key with template <c>"{Country}#{County}#{Locality}"</c> and values "UK", "Derbyshire" and "Matlock":
+    /// <code>
+    /// key.ToSortKeyString(0); // Returns "UK#"
+    /// key.ToSortKeyString(1, false); // Returns "UK#Derbyshire"
+    /// key.ToSortKeyString(1, true); // Returns "UK#Derbyshire#"
+    /// </code>
+    /// </example>
+    string ToSortKeyString(int throughPartIndex, bool includeTrailingDelimiter = true);
+
+    /// <summary>
     /// Parses both partition key and sort key together as strings into a <see cref="TSelf"/> instance.
     /// </summary>
     /// <param name="partitionKey">The partition key string to parse.</param>

--- a/src/CompositeKey/IPrimaryKey`1.cs
+++ b/src/CompositeKey/IPrimaryKey`1.cs
@@ -21,6 +21,22 @@ public interface IPrimaryKey<TSelf> : IFormattable, ISpanParsable<TSelf> where T
     string ToPartitionKeyString();
 
     /// <summary>
+    /// Formats the partition key portion of the current instance to a string through the specified index.
+    /// </summary>
+    /// <param name="throughPartIndex">The zero-based index of the key part to format through (inclusive). This counts only properties and constants, not delimiters.</param>
+    /// <param name="includeTrailingDelimiter">Whether to include the following delimiter character in the formatted string, defaults to true.</param>
+    /// <returns>The partition key portion of the current instance up to the specified index formatted to a string.</returns>
+    /// <example>
+    /// For a key with template <c>"{Country}#{County}#{Locality}"</c> and values "UK", "Derbyshire" and "Matlock":
+    /// <code>
+    /// key.ToPartitionKeyString(0); // Returns "UK#"
+    /// key.ToPartitionKeyString(1, false); // Returns "UK#Derbyshire"
+    /// key.ToPartitionKeyString(1, true); // Returns "UK#Derbyshire#"
+    /// </code>
+    /// </example>
+    string ToPartitionKeyString(int throughPartIndex, bool includeTrailingDelimiter = true);
+
+    /// <summary>
     /// Parses a string into a <see cref="TSelf"/> instance.
     /// </summary>
     /// <param name="primaryKey">The string to parse.</param>

--- a/src/CompositeKey/PublicAPI.Unshipped.txt
+++ b/src/CompositeKey/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+CompositeKey.ICompositePrimaryKey<TSelf>.ToSortKeyString(int throughPartIndex, bool includeTrailingDelimiter = true) -> string!
+CompositeKey.IPrimaryKey<TSelf>.ToPartitionKeyString(int throughPartIndex, bool includeTrailingDelimiter = true) -> string!


### PR DESCRIPTION
Adds two new methods for writing key strings;
- `ToPartitionKeyString(int throughPartIndex, bool includeTrailingDelimiter = true)` in `IPrimaryKey<T>`
- `ToSortKeyString(int throughPartIndex, bool includeTrailingDelimiter = true)` in `ICompositePrimaryKey<T>`

These methods enable formatting keys up to a specific index, with optional trailing delimiters. This is useful for hierarchical queries and prefix matching in databases like DynamoDB.

The `throughPartIndex` parameter is zero-based and inclusive, counting only properties and constants (not delimiters). For example, with a key template `"{Country}#{County}#{Locality}"` and values "UK", "Derbyshire", "Matlock":
- `ToPartitionKeyString(0, false)` returns `"UK"`
- `ToPartitionKeyString(0, true)` returns `"UK#"`
- `ToPartitionKeyString(1, false)` returns `"UK#Derbyshire"`
- `ToPartitionKeyString(1, true)` returns `"UK#Derbyshire#"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new method overloads for partition and sort key formatting with support for dynamic through-part formatting and optional trailing delimiter inclusion.

* **Tests**
  * Added comprehensive test coverage for the new formatting method overloads, including edge cases and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->