### PR TITLE
build: Fix parallel build race on Analyzers.Common deps file

### DIFF
--- a/src/CompositeKey.Analyzers.Common.UnitTests/CompositeKey.Analyzers.Common.UnitTests.csproj
+++ b/src/CompositeKey.Analyzers.Common.UnitTests/CompositeKey.Analyzers.Common.UnitTests.csproj
@@ -34,7 +34,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\CompositeKey\CompositeKey.csproj" />
-        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" />
+        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" GlobalPropertiesToRemove="TargetFramework" />
     </ItemGroup>
 
 </Project>

--- a/src/CompositeKey.Analyzers.UnitTests/CompositeKey.Analyzers.UnitTests.csproj
+++ b/src/CompositeKey.Analyzers.UnitTests/CompositeKey.Analyzers.UnitTests.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
         <ProjectReference Include="..\CompositeKey\CompositeKey.csproj" />
         <ProjectReference Include="..\CompositeKey.Analyzers\CompositeKey.Analyzers.csproj" />
-        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" />
+        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" GlobalPropertiesToRemove="TargetFramework" />
     </ItemGroup>
 
 </Project>

--- a/src/CompositeKey.Analyzers/CompositeKey.Analyzers.csproj
+++ b/src/CompositeKey.Analyzers/CompositeKey.Analyzers.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" PrivateAssets="all" ReferenceOutputAssembly="true" />
+        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" PrivateAssets="all" ReferenceOutputAssembly="true" GlobalPropertiesToRemove="TargetFramework" />
     </ItemGroup>
 
     <Target Name="GetPackAsAnalyzerFiles" DependsOnTargets="$(GenerateNuspecDependsOn);GetCommonAssemblyPath" Returns="@(PackAsAnalyzerFile)">

--- a/src/CompositeKey.SourceGeneration/CompositeKey.SourceGeneration.csproj
+++ b/src/CompositeKey.SourceGeneration/CompositeKey.SourceGeneration.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" PrivateAssets="all" ReferenceOutputAssembly="true" />
+        <ProjectReference Include="..\CompositeKey.Analyzers.Common\CompositeKey.Analyzers.Common.csproj" PrivateAssets="all" ReferenceOutputAssembly="true" GlobalPropertiesToRemove="TargetFramework" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Add GlobalPropertiesToRemove="TargetFramework" to ProjectReference items for CompositeKey.Analyzers.Common in multi-targeted projects.

Without this, each parent TFM passes its own TargetFramework as a global property, causing MSBuild to treat them as separate build requests that can run concurrently—all writing to the same netstandard2.0 output directory and racing on the .deps.json file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal build configuration to optimise project reference handling across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->