### PR TITLE
ci: use ContinuousDelivery mode for GitVersion 6.x compatibility

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 branches:
   main:
-    mode: ContinuousDeployment
+    mode: ContinuousDelivery
     label: preview
 
 major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-,/\\\\]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"


### PR DESCRIPTION
## Summary

- Rename `mode: ContinuousDeployment` to `mode: ContinuousDelivery` in `GitVersion.yml` for GitVersion 6.x compatibility
- GitVersion 6.x renamed the deployment modes: v5's `ContinuousDeployment` is now `ContinuousDelivery`
- Without this change, pre-release labels are not applied and versions resolve as stable releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version management configuration to adjust the release strategy for the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->